### PR TITLE
Add support for customizing publicPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ Default: `'images'`
 
 Folder name inside `/static/` in which the images will get copied to during build.
 
+#### imagesPublicPath
+
+Type: `string`<br>
+Default: ``/_next/static/${imagesFolder}/``
+
+The public path that should be used for image urls. This can be used to serve
+the optimized image from a cloud storage service like S3.
+
 #### imagesName
 
 Type: `string`<br>

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ const withOptimizedImages = (nextConfig) => {
 
   const {
     inlineImageLimit = 8192,
+    imagesPublicPath,
     imagesFolder = 'images',
     imagesName = '[name]-[hash].[ext]',
     optimizeImagesInDev = false,
@@ -132,7 +133,7 @@ const withOptimizedImages = (nextConfig) => {
       const urlLoaderOptions = {
         limit: inlineImageLimit,
         fallback: 'file-loader',
-        publicPath: `/_next/static/${imagesFolder}/`,
+        publicPath: imagesPublicPath || `/_next/static/${imagesFolder}/`,
         outputPath: `static/${imagesFolder}/`,
         name: imagesName,
       };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -246,6 +246,22 @@ describe('next-optimized-images', () => {
       expect(setLimitUrlLoader.options.limit).toEqual(1234);
     });
 
+    test('imagesPublicPath can get set', () => {
+      const defaultPublicPath = getNextConfig();
+      const defaultPublicPathRule = defaultPublicPath.module.rules[0];
+      const defaultPublicPathUrlLoader = defaultPublicPathRule.oneOf[defaultPublicPathRule.oneOf.length - 1].use[0];
+
+      expect(defaultPublicPathUrlLoader.options.publicPath).toEqual('/_next/static/images/');
+      expect(defaultPublicPathUrlLoader.options.outputPath).toEqual('static/images/');
+
+      const setPublicPath = getNextConfig({ imagesPublicPath: 'https://storage.service.com/bucket/foo/bar' });
+      const setPublicPathRule = setPublicPath.module.rules[0];
+      const setPublicPathUrlLoader = setPublicPathRule.oneOf[setPublicPathRule.oneOf.length - 1].use[0];
+
+      expect(setPublicPathUrlLoader.options.publicPath).toEqual('https://storage.service.com/bucket/foo/bar');
+      expect(setPublicPathUrlLoader.options.outputPath).toEqual('static/images/');
+    });
+
     test('imagesFolder can get set', () => {
       const defaultFolder = getNextConfig();
       const defaultFolderRule = defaultFolder.module.rules[0];


### PR DESCRIPTION
Since image assets can take up quite a lot of bandwidth and storage space, it's nice to be able to have them served directly from a cloud storage service like S3.

In this PR I've added a new configuration option, `imagesPublicPath`, which allows you to customize the url generated by `file-loader`.  For example, if you were using google cloud storage:

```js
const optimizedImages = require('next-optimized-images');

let imagesPublicPath;
if (process.env.NODE_ENV === 'production') {
  imagesPublicPath = "https://storage.googleapis.com/my-bucket/images";
}

module.exports = optimizedImages({imagesPublicPath})({
  //...next config here
});
```

Then after building your application, you would sync the images to google cloud storage:

```bash
next build
gsutil -m rsync -r .next/dist/static/images gs://my-bucket/images
```
