### PR TITLE
add imagesOutputPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,13 @@ Default: ``` `/_next/static/${imagesFolder}/` ```
 The public path that should be used for image urls. This can be used to serve
 the optimized image from a cloud storage service like S3.
 
+#### imagesOutputPath
+
+Type: `string`<br>
+Default: ``` `static/${imagesFolder}/` ```
+
+The output path that should be used for images. This can be used to have a custom output folder.
+
 #### imagesName
 
 Type: `string`<br>

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ const withOptimizedImages = (nextConfig) => {
   const {
     inlineImageLimit = 8192,
     imagesPublicPath,
+    imagesOutputPath,
     imagesFolder = 'images',
     imagesName = '[name]-[hash].[ext]',
     optimizeImagesInDev = false,
@@ -134,7 +135,7 @@ const withOptimizedImages = (nextConfig) => {
         limit: inlineImageLimit,
         fallback: 'file-loader',
         publicPath: imagesPublicPath || `/_next/static/${imagesFolder}/`,
-        outputPath: `static/${imagesFolder}/`,
+        outputPath: imagesOutputPath || `static/${imagesFolder}/`,
         name: imagesName,
       };
 


### PR DESCRIPTION
For various reasons I'm using a custom static directory within my project. It would be very useful to also change the output directory to something else than `static`.  

According to the `imagesPublicPath`, I've added an `imagesOutputPath` option.