### PR TITLE
Fix undefined config error with responsive-loader set as default

### DIFF
--- a/lib/loaders/responsive-loader.js
+++ b/lib/loaders/responsive-loader.js
@@ -47,6 +47,8 @@ const applyResponsiveLoader = (webpackConfig, nextConfig, isServer, detectedLoad
       },
     ],
   });
+
+  return webpackConfig
 };
 
 module.exports = {


### PR DESCRIPTION
Currently, if you use `defaultImageLoader: 'responsive-loader'` in your config, your next build will error out because there is no return value at the end of `applyResponsiveLoader`, so your whole webpack/next config becomes `undefined`. 

This should fix that!