### PR TITLE
Fix optimizeImages config when nextComposePlugins is not defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ const withOptimizedImages = (nextConfig = {}, nextComposePlugins = {}) => {
           || (nextComposePlugins.phase === 'phase-export' && optimizeImages)
           || (nextComposePlugins.phase === 'phase-development-server' && optimizeImagesInDev)
         )
-        : (!dev || optimizeImagesInDev);
+        : ((!dev && optimizeImages) || (dev && optimizeImagesInDev));
 
       // show a warning if images should get optimized but no loader is installed
       if (optimizeImages && getNumOptimizationLoadersInstalled(detectedLoaders) === 0 && isServer) {


### PR DESCRIPTION
Disable image optimization when `optimizeImages` is false and `nextComposePlugins` is not defined. Previously, `!dev || optimizeImagesInDev` was returning `true` even though `optimizeImages` was `false`.

Fix #110 