### PR TITLE
Apply workaround for importing images via css #135

### DIFF
--- a/lib/loaders/img-loader.js
+++ b/lib/loaders/img-loader.js
@@ -97,6 +97,10 @@ const applyImgLoader = (
 
   webpackConfig.module.rules.push({
     test: getHandledFilesRegex(handledImageTypes),
+    issuer: {
+      // Next.js already handles url() in css/sass/scss files
+      test: /\.\w+(?<!(s?c|sa)ss)$/i,
+    },
     oneOf: [
       // add all resource queries
       ...getResourceQueries(nextConfig, isServer, optimize ? 'img-loader' : null, imgLoaderOptions, detectedLoaders),


### PR DESCRIPTION
Upstream changes in Next broke image support in css as mentioned in #135 

I've applied the changes from the workaround found by @theshem from https://github.com/zeit/next.js/issues/11164#issuecomment-602005679

It seems to work, although I don't understand why.