### PR TITLE
Add removeOriginalExtension option

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,13 @@ Default: `'[name]-[hash].[ext]'`
 The filename of the optimized images.
 Make sure you keep the `[hash]` part so they receive a new filename if the content changes.
 
+#### removeOriginalExtension
+
+Type: `boolean`<br>
+Default: `false`
+
+When images converted to WebP on the fly, `.webp` was append to the filename. For example, `test.png` became `test.png.webp`. If you want to have only one filename extension like `test.webp`, you can set this option to `true`.
+
 #### optimizeImagesInDev
 
 Type: `boolean`<br>
@@ -714,6 +721,7 @@ module.exports = withPlugins([
     imagesFolder: 'images',
     imagesName: '[name]-[hash].[ext]',
     handleImages: ['jpeg', 'png', 'svg', 'webp', 'gif'],
+    removeOriginalExtension: false,
     optimizeImages: true,
     optimizeImagesInDev: false,
     mozjpeg: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ const getConfig = nextConfig => ({
   handleImages: ['jpeg', 'png', 'svg', 'webp', 'gif'],
   imagesFolder: 'images',
   imagesName: '[name]-[hash].[ext]',
+  removeOriginalExtension: false,
   inlineImageLimit: 8192,
   defaultImageLoader: 'img-loader',
   mozjpeg: {},

--- a/lib/loaders/webp-loader.js
+++ b/lib/loaders/webp-loader.js
@@ -60,7 +60,7 @@ const applyWebpLoader = (webpackConfig, nextConfig, optimize, isServer, detectLo
 const getWebpResourceQuery = (nextConfig, isServer) => {
   const urlLoaderOptions = getUrlLoaderOptions(nextConfig, isServer);
   const imageName = urlLoaderOptions.name.indexOf('[ext]') >= 0
-    ? urlLoaderOptions.name.replace('[ext]', '[ext].webp')
+    ? urlLoaderOptions.name.replace('[ext]', nextConfig.removeOriginalExtension ? 'webp' : '[ext].webp')
     : `${urlLoaderOptions.name}.webp`;
 
   return {


### PR DESCRIPTION
This PR add a new option called `removeOriginalExtension`. 

When images converted to WebP on the fly, `.webp` was append to the filename. For example, `test.png` became `test.png.webp`. If you want to have only one filename extension like `test.webp`, you can set this option to `true`.

The motivation is because for some CDN services(like Azure CDN), it decides response header `content-type` by filename and it failed to recognize multiple filename extensions like `.png.webp`, so the `content-type` will be default value which is `application/octet-stream`. 

There is no option to disable this behavior for now so I purpose this PR. Please let me know if there is any problem, and thanks for making this awesome library 😄 