### PR TITLE
Switch to @memrise/lqip

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 90
+}

--- a/lib/loaders/img-loader.js
+++ b/lib/loaders/img-loader.js
@@ -14,7 +14,9 @@ const requireImageminPlugin = (plugin, nextConfig) => {
   let moduleName = plugin;
 
   if (nextConfig.overwriteImageLoaderPaths) {
-    moduleName = require.resolve(plugin, { paths: [nextConfig.overwriteImageLoaderPaths] });
+    moduleName = require.resolve(plugin, {
+      paths: [nextConfig.overwriteImageLoaderPaths],
+    });
   }
 
   /* eslint global-require: "off", import/no-dynamic-require: "off" */
@@ -99,16 +101,25 @@ const applyImgLoader = (
     test: getHandledFilesRegex(handledImageTypes),
     oneOf: [
       // add all resource queries
-      ...getResourceQueries(nextConfig, isServer, optimize ? 'img-loader' : null, imgLoaderOptions, detectedLoaders),
+      ...getResourceQueries(
+        nextConfig,
+        isServer,
+        optimize ? 'img-loader' : null,
+        imgLoaderOptions,
+        detectedLoaders,
+      ),
 
       // ?webp: convert an image to webp
-      handledImageTypes.webp
-        ? getWebpResourceQuery(nextConfig, isServer)
-        : undefined,
+      handledImageTypes.webp ? getWebpResourceQuery(nextConfig, isServer) : undefined,
 
       // ?sprite: add icon to sprite
       detectedLoaders.svgSprite
-        ? getSvgSpriteLoaderResourceQuery(nextConfig, detectedLoaders, imgLoaderOptions, optimize)
+        ? getSvgSpriteLoaderResourceQuery(
+            nextConfig,
+            detectedLoaders,
+            imgLoaderOptions,
+            optimize,
+          )
         : undefined,
 
       // default behavior: inline if below the definied limit, external file if above

--- a/lib/resource-queries.js
+++ b/lib/resource-queries.js
@@ -20,9 +20,11 @@ const queries = [
   {
     test: 'inline',
     loaders: ['url-loader'],
-    options: [{
-      limit: undefined,
-    }],
+    options: [
+      {
+        limit: undefined,
+      },
+    ],
     optimize: true,
     combinations: ['original'],
   },
@@ -30,10 +32,7 @@ const queries = [
   // ?include: include the image directly, no data uri or external file
   {
     test: 'include',
-    loaders: [
-      require.resolve('./loaders/raw-loader/export-loader.js'),
-      'raw-loader',
-    ],
+    loaders: [require.resolve('./loaders/raw-loader/export-loader.js'), 'raw-loader'],
     optimize: true,
     combinations: ['original'],
   },
@@ -50,7 +49,7 @@ const queries = [
     test: 'lqip(&|$)',
     loaders: [
       require.resolve('./loaders/lqip-loader/picture-export-loader.js'),
-      'lqip-loader',
+      '@memrise/lqip-loader',
       'url-loader',
     ],
     optimize: false,
@@ -61,32 +60,30 @@ const queries = [
     test: 'lqip-colors',
     loaders: [
       require.resolve('./loaders/lqip-loader/colors-export-loader.js'),
-      'lqip-loader',
+      '@memrise/lqip-loader',
       'url-loader',
     ],
-    options: [{}, {
-      base64: false,
-      palette: true,
-    }],
+    options: [
+      {},
+      {
+        base64: false,
+        palette: true,
+      },
+    ],
     optimize: false,
   },
 
   // ?resize: resize images
   {
     test: 'size',
-    loaders: [
-      'responsive-loader',
-    ],
+    loaders: ['responsive-loader'],
     optimize: false,
   },
 
   // ?trace: generate svg image traces for placeholders
   {
     test: 'trace',
-    loaders: [
-      'image-trace-loader',
-      'url-loader',
-    ],
+    loaders: ['image-trace-loader', 'url-loader'],
     optimize: true,
     combinations: ['original'],
   },
@@ -129,7 +126,7 @@ const getResourceQueries = (
     'url-loader': getUrlLoaderOptions(nextConfig, isServer),
     'file-loader': getFileLoaderOptions(nextConfig, isServer),
     [getFileLoaderPath()]: getFileLoaderOptions(nextConfig, isServer),
-    'lqip-loader': getLqipLoaderOptions(nextConfig, isServer),
+    '@memrise/lqip-loader': getLqipLoaderOptions(nextConfig, isServer),
     'responsive-loader': getResponsiveLoaderOptions(nextConfig, isServer, detectLoaders),
     'image-trace-loader': getImageTraceLoaderOptions(nextConfig),
   };
@@ -158,12 +155,16 @@ const getResourceQueries = (
 
     return {
       resourceQuery: new RegExp(queryConfig.test),
-      use: loaders.concat(queryConfig.optimize && optimizerLoaderName !== null ? [
-        {
-          loader: optimizerLoaderName,
-          options: optimizerLoaderOptions,
-        },
-      ] : []),
+      use: loaders.concat(
+        queryConfig.optimize && optimizerLoaderName !== null
+          ? [
+              {
+                loader: optimizerLoaderName,
+                options: optimizerLoaderOptions,
+              },
+            ]
+          : [],
+      ),
     };
   });
 };


### PR DESCRIPTION
Fix for https://github.com/cyrilwanner/next-optimized-images/issues/192

Our team was receiving a [dependency security advisory for url-regex](https://www.npmjs.com/advisories/1550), required by the dependency chain: `lqip-loader` → `lqip` → `jimp` → `url-regex`. Although `jimp` no longer depends on `url-regex`, `lqip` was using an older version of `jimp` which did.

There are two ways I think this issue can be fixed and I've taken steps along both paths.

My preferred route is to upgrade `jimp` in `lqip`, then upgrade `lqip-loader` and we're done. I've made a [PR to lqip to upgrade jimp here](https://github.com/zouhir/lqip/pull/18).

However, since `lqip` and `lqip-loader` no longer appear to be supported, I've also forked each of these repos to @memrise (https://github.com/Memrise/lqip-loader and https://github.com/Memrise/lqip) and made this PR to use `@memrise/lqip-loader` instead of `lqip`. This is a little more awkward and I'm not 100% confident in my changes but it is a good backup fix.

What I'd like is either for a check over of this PR and a merge or suggestion as to how we can get the original lqip-loader upgraded. Longer term, I'd love for there to be a plan for moving away from unsupported dependencies such as these.

Apologies for the formatting changes. I have my editor set to auto-prettify and I noticed you don't yet have a `.prettierrc` so I added one along the way to avoid issues like this in the future. Happy to set up proper CI for this if you think it's a good idea!
