### PR TITLE
#117: Import through SASS URL does not work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,13 @@ const withOptimizedImages = (nextConfig = {}, nextComposePlugins = {}) => {
                 subRule.issuer && !subRule.test && !subRule.include && subRule.exclude
                 && subRule.use && subRule.use.options && subRule.use.options.name
               ) {
-                if ((String(subRule.issuer.test) === '/\\.(css|scss|sass)$/' || String(subRule.issuer) === '/\\.(css|scss|sass)$/') && subRule.use.options.name.startsWith('static/media/')) {
+                if (
+                  (
+                    String(subRule.issuer.test) === '/\\.(css|scss|sass)$/' ||
+                    String(subRule.issuer) === '/\\.(css|scss|sass)$/' ||
+                    String(subRule.issuer) === '/\\.(css|scss|sass)(\\.webpack\\[javascript\\/auto\\])?$/'
+                  ) && subRule.use.options.name.startsWith('static/media/')
+                ) {
                   subRule.exclude.push(/\.(jpg|jpeg|png|svg|webp|gif|ico)$/);
                 }
               }


### PR DESCRIPTION
#177 

Regex was changed in the last version of Next.JS  - https://github.com/vercel/next.js/blob/master/packages/next/build/webpack/config/blocks/css/index.ts#L17