### PR TITLE
add custom loader to next.config.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ module.exports = withPlugins([
     /* config for next-optimized-images */
   }],
 
+  // tell Next.js that you are using a custom loader
+  images: {
+    loader: 'custom'
+  }
+  
   // your other plugins here
 
 ]);


### PR DESCRIPTION
In order to get my Next.js project to export using `next export` I had to add this code to the next.config.js:

```
images: {
  loader: 'custom'
}
```

See https://github.com/vercel/next.js/issues/21079#issuecomment-899535752